### PR TITLE
if no ticket received from ptc auth, call didNotReceiveAuth handler

### DIFF
--- a/PGoApi/Classes/PtcOAuth.swift
+++ b/PGoApi/Classes/PtcOAuth.swift
@@ -43,9 +43,14 @@ public class PtcOAuth: PGoAuth {
             .responseData { response in
                 if let location = response.response!.allHeaderFields["Location"] as? String {
                     let ticketRange = location.rangeOfString("?ticket=")
-                    let ticket = String(location.characters.suffixFrom(ticketRange!.endIndex))
                     
-                    self.loginOAuth(ticket)
+                    // response will occasionally come back with no ticket arg
+                    if ticketRange == nil {
+                        self.delegate?.didNotReceiveAuth()
+                    } else {
+                        let ticket = String(location.characters.suffixFrom(ticketRange!.endIndex))
+                        self.loginOAuth(ticket)
+                    }
                 } else {
                     self.delegate?.didNotReceiveAuth()
                 }


### PR DESCRIPTION
Occasionally the request made in PtcOAuth.getTicket() will return a response without the ticket argument. I'm not sure exactly what's causing this but right now the code just crashes when this happens.

Instead, this PR will call the delegate's didNotReceiveAuth handler when this happens.
