### PR TITLE
Fix to add override prefixes

### DIFF
--- a/PGoApi/Classes/protos/Pogoprotos.Data.Badge.PogoprotosDataBadge.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Data.Badge.PogoprotosDataBadge.proto.swift
@@ -214,7 +214,7 @@ public extension Pogoprotos.Data.Badge {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Badge.BadgeCaptureReward.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Badge.BadgeCaptureReward.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Badge.BadgeCaptureReward.Builder()
         if let jsonValueCaptureRewardMultiplier = jsonMap["captureRewardMultiplier"] as? NSNumber {
           resultDecodedBuilder.captureRewardMultiplier = jsonValueCaptureRewardMultiplier.floatValue

--- a/PGoApi/Classes/protos/Pogoprotos.Data.Battle.PogoprotosDataBattle.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Data.Battle.PogoprotosDataBattle.proto.swift
@@ -1119,7 +1119,7 @@ public extension Pogoprotos.Data.Battle {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Battle.BattleAction.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Battle.BattleAction.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Battle.BattleAction.Builder()
         if let jsonValueType = jsonMap["type"] as? String {
           resultDecodedBuilder.type = try Pogoprotos.Data.Battle.BattleActionType.fromString(str: jsonValueType)
@@ -1601,7 +1601,7 @@ public extension Pogoprotos.Data.Battle {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Battle.BattleLog.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Battle.BattleLog.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Battle.BattleLog.Builder()
         if let jsonValueState = jsonMap["state"] as? String {
           resultDecodedBuilder.state = try Pogoprotos.Data.Battle.BattleState.fromString(str: jsonValueState)
@@ -2045,7 +2045,7 @@ public extension Pogoprotos.Data.Battle {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Battle.BattleParticipant.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Battle.BattleParticipant.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Battle.BattleParticipant.Builder()
         if let jsonValueActivePokemon = jsonMap["activePokemon"] as? Dictionary<String,Any> {
           resultDecodedBuilder.activePokemon = try Pogoprotos.Data.Battle.BattlePokemonInfo.Builder.decodeToBuilder(jsonMap:jsonValueActivePokemon).build()
@@ -2400,7 +2400,7 @@ public extension Pogoprotos.Data.Battle {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Battle.BattlePokemonInfo.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Battle.BattlePokemonInfo.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Battle.BattlePokemonInfo.Builder()
         if let jsonValuePokemonData = jsonMap["pokemonData"] as? Dictionary<String,Any> {
           resultDecodedBuilder.pokemonData = try Pogoprotos.Data.PokemonData.Builder.decodeToBuilder(jsonMap:jsonValuePokemonData).build()
@@ -2849,7 +2849,7 @@ public extension Pogoprotos.Data.Battle {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Battle.BattleResults.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Battle.BattleResults.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Battle.BattleResults.Builder()
         if let jsonValueGymState = jsonMap["gymState"] as? Dictionary<String,Any> {
           resultDecodedBuilder.gymState = try Pogoprotos.Data.Gym.GymState.Builder.decodeToBuilder(jsonMap:jsonValueGymState).build()

--- a/PGoApi/Classes/protos/Pogoprotos.Data.Capture.PogoprotosDataCapture.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Data.Capture.PogoprotosDataCapture.proto.swift
@@ -433,7 +433,7 @@ public extension Pogoprotos.Data.Capture {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Capture.CaptureAward.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Capture.CaptureAward.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Capture.CaptureAward.Builder()
         if let jsonValueActivityType = jsonMap["activityType"] as? Array<String> {
           var jsonArrayActivityType:Array<Pogoprotos.Enums.ActivityType> = []
@@ -782,7 +782,7 @@ public extension Pogoprotos.Data.Capture {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Capture.CaptureProbability.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Capture.CaptureProbability.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Capture.CaptureProbability.Builder()
         if let jsonValuePokeballType = jsonMap["pokeballType"] as? Array<String> {
           var jsonArrayPokeballType:Array<Pogoprotos.Inventory.Item.ItemId> = []

--- a/PGoApi/Classes/protos/Pogoprotos.Data.Gym.PogoprotosDataGym.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Data.Gym.PogoprotosDataGym.proto.swift
@@ -445,7 +445,7 @@ public extension Pogoprotos.Data.Gym {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Gym.GymMembership.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Gym.GymMembership.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Gym.GymMembership.Builder()
         if let jsonValuePokemonData = jsonMap["pokemonData"] as? Dictionary<String,Any> {
           resultDecodedBuilder.pokemonData = try Pogoprotos.Data.PokemonData.Builder.decodeToBuilder(jsonMap:jsonValuePokemonData).build()
@@ -788,7 +788,7 @@ public extension Pogoprotos.Data.Gym {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Gym.GymState.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Gym.GymState.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Gym.GymState.Builder()
         if let jsonValueFortData = jsonMap["fortData"] as? Dictionary<String,Any> {
           resultDecodedBuilder.fortData = try Pogoprotos.Map.Fort.FortData.Builder.decodeToBuilder(jsonMap:jsonValueFortData).build()

--- a/PGoApi/Classes/protos/Pogoprotos.Data.Logs.PogoprotosDataLogs.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Data.Logs.PogoprotosDataLogs.proto.swift
@@ -667,7 +667,7 @@ public extension Pogoprotos.Data.Logs {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Logs.ActionLogEntry.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Logs.ActionLogEntry.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Logs.ActionLogEntry.Builder()
         if let jsonValueTimestampMs = jsonMap["timestampMs"] as? String {
           resultDecodedBuilder.timestampMs = Int64(jsonValueTimestampMs)!
@@ -1014,7 +1014,7 @@ public extension Pogoprotos.Data.Logs {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Logs.BuddyPokemonLogEntry.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Logs.BuddyPokemonLogEntry.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Logs.BuddyPokemonLogEntry.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Data.Logs.BuddyPokemonLogEntry.Result.fromString(str: jsonValueResult)
@@ -1407,7 +1407,7 @@ public extension Pogoprotos.Data.Logs {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Logs.CatchPokemonLogEntry.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Logs.CatchPokemonLogEntry.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Logs.CatchPokemonLogEntry.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Data.Logs.CatchPokemonLogEntry.Result.fromString(str: jsonValueResult)
@@ -1793,7 +1793,7 @@ public extension Pogoprotos.Data.Logs {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Logs.FortSearchLogEntry.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Logs.FortSearchLogEntry.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Logs.FortSearchLogEntry.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Data.Logs.FortSearchLogEntry.Result.fromString(str: jsonValueResult)

--- a/PGoApi/Classes/protos/Pogoprotos.Data.Player.PogoprotosDataPlayer.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Data.Player.PogoprotosDataPlayer.proto.swift
@@ -379,7 +379,7 @@ public extension Pogoprotos.Data.Player {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.ContactSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.ContactSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Player.ContactSettings.Builder()
         if let jsonValueSendMarketingEmails = jsonMap["sendMarketingEmails"] as? Bool {
           resultDecodedBuilder.sendMarketingEmails = jsonValueSendMarketingEmails
@@ -627,7 +627,7 @@ public extension Pogoprotos.Data.Player {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.Currency.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.Currency.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Player.Currency.Builder()
         if let jsonValueName = jsonMap["name"] as? String {
           resultDecodedBuilder.name = jsonValueName
@@ -875,7 +875,7 @@ public extension Pogoprotos.Data.Player {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.DailyBonus.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.DailyBonus.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Player.DailyBonus.Builder()
         if let jsonValueNextCollectedTimestampMs = jsonMap["nextCollectedTimestampMs"] as? String {
           resultDecodedBuilder.nextCollectedTimestampMs = Int64(jsonValueNextCollectedTimestampMs)!
@@ -1174,7 +1174,7 @@ public extension Pogoprotos.Data.Player {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.EquippedBadge.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.EquippedBadge.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Player.EquippedBadge.Builder()
         if let jsonValueBadgeType = jsonMap["badgeType"] as? String {
           resultDecodedBuilder.badgeType = try Pogoprotos.Enums.BadgeType.fromString(str: jsonValueBadgeType)
@@ -1758,7 +1758,7 @@ public extension Pogoprotos.Data.Player {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.PlayerAvatar.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.PlayerAvatar.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Player.PlayerAvatar.Builder()
         if let jsonValueSkin = jsonMap["skin"] as? NSNumber {
           resultDecodedBuilder.skin = jsonValueSkin.int32Value
@@ -1980,7 +1980,7 @@ public extension Pogoprotos.Data.Player {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.PlayerCamera.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.PlayerCamera.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Player.PlayerCamera.Builder()
         if let jsonValueIsDefaultCamera = jsonMap["isDefaultCamera"] as? Bool {
           resultDecodedBuilder.isDefaultCamera = jsonValueIsDefaultCamera
@@ -2178,7 +2178,7 @@ public extension Pogoprotos.Data.Player {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.PlayerCurrency.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.PlayerCurrency.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Player.PlayerCurrency.Builder()
         if let jsonValueGems = jsonMap["gems"] as? NSNumber {
           resultDecodedBuilder.gems = jsonValueGems.int32Value
@@ -2510,7 +2510,7 @@ public extension Pogoprotos.Data.Player {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.PlayerPublicProfile.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.PlayerPublicProfile.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Player.PlayerPublicProfile.Builder()
         if let jsonValueName = jsonMap["name"] as? String {
           resultDecodedBuilder.name = jsonValueName
@@ -3763,7 +3763,7 @@ public extension Pogoprotos.Data.Player {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.PlayerStats.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Player.PlayerStats.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Player.PlayerStats.Builder()
         if let jsonValueLevel = jsonMap["level"] as? NSNumber {
           resultDecodedBuilder.level = jsonValueLevel.int32Value

--- a/PGoApi/Classes/protos/Pogoprotos.Data.PogoprotosData.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Data.PogoprotosData.proto.swift
@@ -598,7 +598,7 @@ public extension Pogoprotos.Data {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.AssetDigestEntry.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.AssetDigestEntry.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.AssetDigestEntry.Builder()
         if let jsonValueAssetId = jsonMap["assetId"] as? String {
           resultDecodedBuilder.assetId = jsonValueAssetId
@@ -905,7 +905,7 @@ public extension Pogoprotos.Data {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.BackgroundToken.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.BackgroundToken.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.BackgroundToken.Builder()
         if let jsonValueToken = jsonMap["token"] as? String {
           resultDecodedBuilder.token = Data(base64Encoded:jsonValueToken, options: Data.Base64DecodingOptions(rawValue:0))!
@@ -1203,7 +1203,7 @@ public extension Pogoprotos.Data {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.BuddyPokemon.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.BuddyPokemon.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.BuddyPokemon.Builder()
         if let jsonValueId = jsonMap["id"] as? String {
           resultDecodedBuilder.id = UInt64(jsonValueId)!
@@ -1407,7 +1407,7 @@ public extension Pogoprotos.Data {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.ClientVersion.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.ClientVersion.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.ClientVersion.Builder()
         if let jsonValueMinVersion = jsonMap["minVersion"] as? String {
           resultDecodedBuilder.minVersion = jsonValueMinVersion
@@ -1746,7 +1746,7 @@ public extension Pogoprotos.Data {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.DownloadUrlEntry.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.DownloadUrlEntry.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.DownloadUrlEntry.Builder()
         if let jsonValueAssetId = jsonMap["assetId"] as? String {
           resultDecodedBuilder.assetId = jsonValueAssetId
@@ -2145,7 +2145,7 @@ public extension Pogoprotos.Data {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.PlayerBadge.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.PlayerBadge.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.PlayerBadge.Builder()
         if let jsonValueBadgeType = jsonMap["badgeType"] as? String {
           resultDecodedBuilder.badgeType = try Pogoprotos.Enums.BadgeType.fromString(str: jsonValueBadgeType)
@@ -3191,7 +3191,7 @@ public extension Pogoprotos.Data {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.PlayerData.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.PlayerData.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.PlayerData.Builder()
         if let jsonValueCreationTimestampMs = jsonMap["creationTimestampMs"] as? String {
           resultDecodedBuilder.creationTimestampMs = Int64(jsonValueCreationTimestampMs)!
@@ -3636,7 +3636,7 @@ public extension Pogoprotos.Data {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.PokedexEntry.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.PokedexEntry.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.PokedexEntry.Builder()
         if let jsonValuePokemonId = jsonMap["pokemonId"] as? String {
           resultDecodedBuilder.pokemonId = try Pogoprotos.Enums.PokemonId.fromString(str: jsonValuePokemonId)
@@ -5413,7 +5413,7 @@ public extension Pogoprotos.Data {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.PokemonData.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.PokemonData.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.PokemonData.Builder()
         if let jsonValueId = jsonMap["id"] as? String {
           resultDecodedBuilder.id = UInt64(jsonValueId)!

--- a/PGoApi/Classes/protos/Pogoprotos.Data.Quests.PogoprotosDataQuests.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Data.Quests.PogoprotosDataQuests.proto.swift
@@ -274,7 +274,7 @@ public extension Pogoprotos.Data.Quests {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Quests.DailyQuest.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Quests.DailyQuest.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Quests.DailyQuest.Builder()
         if let jsonValueCurrentPeriodBucket = jsonMap["currentPeriodBucket"] as? NSNumber {
           resultDecodedBuilder.currentPeriodBucket = jsonValueCurrentPeriodBucket.int32Value
@@ -566,7 +566,7 @@ public extension Pogoprotos.Data.Quests {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Quests.Quest.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Quests.Quest.Builder {
         let resultDecodedBuilder = Pogoprotos.Data.Quests.Quest.Builder()
         if let jsonValueQuestType = jsonMap["questType"] as? String {
           resultDecodedBuilder.questType = try Pogoprotos.Enums.QuestType.fromString(str: jsonValueQuestType)

--- a/PGoApi/Classes/protos/Pogoprotos.Inventory.Item.PogoprotosInventoryItem.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Inventory.Item.PogoprotosInventoryItem.proto.swift
@@ -498,7 +498,7 @@ public extension Pogoprotos.Inventory.Item {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.Item.ItemAward.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.Item.ItemAward.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.Item.ItemAward.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueItemId)
@@ -797,7 +797,7 @@ public extension Pogoprotos.Inventory.Item {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.Item.ItemData.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.Item.ItemData.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.Item.ItemData.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueItemId)

--- a/PGoApi/Classes/protos/Pogoprotos.Inventory.PogoprotosInventory.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Inventory.PogoprotosInventory.proto.swift
@@ -582,7 +582,7 @@ public extension Pogoprotos.Inventory {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.AppliedItem.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.AppliedItem.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.AppliedItem.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueItemId)
@@ -791,7 +791,7 @@ public extension Pogoprotos.Inventory {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.AppliedItems.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.AppliedItems.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.AppliedItems.Builder()
         if let jsonValueItem = jsonMap["item"] as? Array<Dictionary<String,Any>> {
           var jsonArrayItem:Array<Pogoprotos.Inventory.AppliedItem> = []
@@ -1046,7 +1046,7 @@ public extension Pogoprotos.Inventory {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.Candy.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.Candy.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.Candy.Builder()
         if let jsonValueFamilyId = jsonMap["familyId"] as? String {
           resultDecodedBuilder.familyId = try Pogoprotos.Enums.PokemonFamilyId.fromString(str: jsonValueFamilyId)
@@ -1538,7 +1538,7 @@ public extension Pogoprotos.Inventory {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.EggIncubator.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.EggIncubator.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.EggIncubator.Builder()
         if let jsonValueId = jsonMap["id"] as? String {
           resultDecodedBuilder.id = jsonValueId
@@ -1756,7 +1756,7 @@ public extension Pogoprotos.Inventory {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.EggIncubators.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.EggIncubators.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.EggIncubators.Builder()
         if let jsonValueEggIncubator = jsonMap["eggIncubator"] as? Array<Dictionary<String,Any>> {
           var jsonArrayEggIncubator:Array<Pogoprotos.Inventory.EggIncubator> = []
@@ -2056,7 +2056,7 @@ public extension Pogoprotos.Inventory {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryDelta.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryDelta.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.InventoryDelta.Builder()
         if let jsonValueOriginalTimestampMs = jsonMap["originalTimestampMs"] as? String {
           resultDecodedBuilder.originalTimestampMs = Int64(jsonValueOriginalTimestampMs)!
@@ -2271,7 +2271,7 @@ public extension Pogoprotos.Inventory {
               }
             }
           }
-          class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryItem.DeletedItem.Builder {
+          override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryItem.DeletedItem.Builder {
             let resultDecodedBuilder = Pogoprotos.Inventory.InventoryItem.DeletedItem.Builder()
             if let jsonValuePokemonId = jsonMap["pokemonId"] as? String {
               resultDecodedBuilder.pokemonId = UInt64(jsonValuePokemonId)!
@@ -2644,7 +2644,7 @@ public extension Pogoprotos.Inventory {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryItem.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryItem.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.InventoryItem.Builder()
         if let jsonValueModifiedTimestampMs = jsonMap["modifiedTimestampMs"] as? String {
           resultDecodedBuilder.modifiedTimestampMs = Int64(jsonValueModifiedTimestampMs)!
@@ -3760,7 +3760,7 @@ public extension Pogoprotos.Inventory {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryItemData.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryItemData.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.InventoryItemData.Builder()
         if let jsonValuePokemonData = jsonMap["pokemonData"] as? Dictionary<String,Any> {
           resultDecodedBuilder.pokemonData = try Pogoprotos.Data.PokemonData.Builder.decodeToBuilder(jsonMap:jsonValuePokemonData).build()
@@ -4481,7 +4481,7 @@ public extension Pogoprotos.Inventory {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryKey.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryKey.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.InventoryKey.Builder()
         if let jsonValuePokemonId = jsonMap["pokemonId"] as? String {
           resultDecodedBuilder.pokemonId = UInt64(jsonValuePokemonId)!
@@ -4811,7 +4811,7 @@ public extension Pogoprotos.Inventory {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryUpgrade.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryUpgrade.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.InventoryUpgrade.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueItemId)
@@ -5017,7 +5017,7 @@ public extension Pogoprotos.Inventory {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryUpgrades.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Inventory.InventoryUpgrades.Builder {
         let resultDecodedBuilder = Pogoprotos.Inventory.InventoryUpgrades.Builder()
         if let jsonValueInventoryUpgrades = jsonMap["inventoryUpgrades"] as? Array<Dictionary<String,Any>> {
           var jsonArrayInventoryUpgrades:Array<Pogoprotos.Inventory.InventoryUpgrade> = []

--- a/PGoApi/Classes/protos/Pogoprotos.Map.Fort.PogoprotosMapFort.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Map.Fort.PogoprotosMapFort.proto.swift
@@ -1204,7 +1204,7 @@ public extension Pogoprotos.Map.Fort {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Fort.FortData.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Fort.FortData.Builder {
         let resultDecodedBuilder = Pogoprotos.Map.Fort.FortData.Builder()
         if let jsonValueId = jsonMap["id"] as? String {
           resultDecodedBuilder.id = jsonValueId
@@ -1601,7 +1601,7 @@ public extension Pogoprotos.Map.Fort {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Fort.FortLureInfo.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Fort.FortLureInfo.Builder {
         let resultDecodedBuilder = Pogoprotos.Map.Fort.FortLureInfo.Builder()
         if let jsonValueFortId = jsonMap["fortId"] as? String {
           resultDecodedBuilder.fortId = jsonValueFortId
@@ -1906,7 +1906,7 @@ public extension Pogoprotos.Map.Fort {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Fort.FortModifier.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Fort.FortModifier.Builder {
         let resultDecodedBuilder = Pogoprotos.Map.Fort.FortModifier.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueItemId)
@@ -2251,7 +2251,7 @@ public extension Pogoprotos.Map.Fort {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Fort.FortSummary.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Fort.FortSummary.Builder {
         let resultDecodedBuilder = Pogoprotos.Map.Fort.FortSummary.Builder()
         if let jsonValueFortSummaryId = jsonMap["fortSummaryId"] as? String {
           resultDecodedBuilder.fortSummaryId = jsonValueFortSummaryId

--- a/PGoApi/Classes/protos/Pogoprotos.Map.PogoprotosMap.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Map.PogoprotosMap.proto.swift
@@ -756,7 +756,7 @@ public extension Pogoprotos.Map {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.MapCell.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.MapCell.Builder {
         let resultDecodedBuilder = Pogoprotos.Map.MapCell.Builder()
         if let jsonValueS2CellId = jsonMap["s2CellId"] as? String {
           resultDecodedBuilder.s2CellId = UInt64(jsonValueS2CellId)!
@@ -1073,7 +1073,7 @@ public extension Pogoprotos.Map {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.SpawnPoint.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.SpawnPoint.Builder {
         let resultDecodedBuilder = Pogoprotos.Map.SpawnPoint.Builder()
         if let jsonValueLatitude = jsonMap["latitude"] as? NSNumber {
           resultDecodedBuilder.latitude = jsonValueLatitude.doubleValue

--- a/PGoApi/Classes/protos/Pogoprotos.Map.Pokemon.PogoprotosMapPokemon.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Map.Pokemon.PogoprotosMapPokemon.proto.swift
@@ -491,7 +491,7 @@ public extension Pogoprotos.Map.Pokemon {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Pokemon.MapPokemon.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Pokemon.MapPokemon.Builder {
         let resultDecodedBuilder = Pogoprotos.Map.Pokemon.MapPokemon.Builder()
         if let jsonValueSpawnPointId = jsonMap["spawnPointId"] as? String {
           resultDecodedBuilder.spawnPointId = jsonValueSpawnPointId
@@ -896,7 +896,7 @@ public extension Pogoprotos.Map.Pokemon {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Pokemon.NearbyPokemon.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Pokemon.NearbyPokemon.Builder {
         let resultDecodedBuilder = Pogoprotos.Map.Pokemon.NearbyPokemon.Builder()
         if let jsonValuePokemonId = jsonMap["pokemonId"] as? String {
           resultDecodedBuilder.pokemonId = try Pogoprotos.Enums.PokemonId.fromString(str: jsonValuePokemonId)
@@ -1428,7 +1428,7 @@ public extension Pogoprotos.Map.Pokemon {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Pokemon.WildPokemon.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Map.Pokemon.WildPokemon.Builder {
         let resultDecodedBuilder = Pogoprotos.Map.Pokemon.WildPokemon.Builder()
         if let jsonValueEncounterId = jsonMap["encounterId"] as? String {
           resultDecodedBuilder.encounterId = UInt64(jsonValueEncounterId)!

--- a/PGoApi/Classes/protos/Pogoprotos.Networking.Envelopes.PogoprotosNetworkingEnvelopes.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Networking.Envelopes.PogoprotosNetworkingEnvelopes.proto.swift
@@ -539,7 +539,7 @@ public extension Pogoprotos.Networking.Envelopes {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.AuthTicket.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.AuthTicket.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.AuthTicket.Builder()
         if let jsonValueStart = jsonMap["start"] as? String {
           resultDecodedBuilder.start = Data(base64Encoded:jsonValueStart, options: Data.Base64DecodingOptions(rawValue:0))!
@@ -800,7 +800,7 @@ public extension Pogoprotos.Networking.Envelopes {
                   }
                 }
               }
-              class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.RequestEnvelope.AuthInfo.Jwt.Builder {
+              override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.RequestEnvelope.AuthInfo.Jwt.Builder {
                 let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.RequestEnvelope.AuthInfo.Jwt.Builder()
                 if let jsonValueContents = jsonMap["contents"] as? String {
                   resultDecodedBuilder.contents = jsonValueContents
@@ -1089,7 +1089,7 @@ public extension Pogoprotos.Networking.Envelopes {
               }
             }
           }
-          class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.RequestEnvelope.AuthInfo.Builder {
+          override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.RequestEnvelope.AuthInfo.Builder {
             let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.RequestEnvelope.AuthInfo.Builder()
             if let jsonValueProvider = jsonMap["provider"] as? String {
               resultDecodedBuilder.provider = jsonValueProvider
@@ -1348,7 +1348,7 @@ public extension Pogoprotos.Networking.Envelopes {
               }
             }
           }
-          class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.RequestEnvelope.PlatformRequest.Builder {
+          override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.RequestEnvelope.PlatformRequest.Builder {
             let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.RequestEnvelope.PlatformRequest.Builder()
             if let jsonValueType = jsonMap["type"] as? String {
               resultDecodedBuilder.type = try Pogoprotos.Networking.Platform.PlatformRequestType.fromString(str: jsonValueType)
@@ -2058,7 +2058,7 @@ public extension Pogoprotos.Networking.Envelopes {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.RequestEnvelope.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.RequestEnvelope.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.RequestEnvelope.Builder()
         if let jsonValueStatusCode = jsonMap["statusCode"] as? NSNumber {
           resultDecodedBuilder.statusCode = jsonValueStatusCode.int32Value
@@ -2353,7 +2353,7 @@ public extension Pogoprotos.Networking.Envelopes {
               }
             }
           }
-          class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.ResponseEnvelope.PlatformResponse.Builder {
+          override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.ResponseEnvelope.PlatformResponse.Builder {
             let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.ResponseEnvelope.PlatformResponse.Builder()
             if let jsonValueType = jsonMap["type"] as? String {
               resultDecodedBuilder.type = try Pogoprotos.Networking.Platform.PlatformRequestType.fromString(str: jsonValueType)
@@ -2961,7 +2961,7 @@ public extension Pogoprotos.Networking.Envelopes {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.ResponseEnvelope.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.ResponseEnvelope.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.ResponseEnvelope.Builder()
         if let jsonValueStatusCode = jsonMap["statusCode"] as? String {
           resultDecodedBuilder.statusCode = try Pogoprotos.Networking.Envelopes.ResponseEnvelope.StatusCode.fromString(str: jsonValueStatusCode)
@@ -3720,7 +3720,7 @@ public extension Pogoprotos.Networking.Envelopes {
               }
             }
           }
-          class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.Signature.LocationFix.Builder {
+          override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.Signature.LocationFix.Builder {
             let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.Signature.LocationFix.Builder()
             if let jsonValueProvider = jsonMap["provider"] as? String {
               resultDecodedBuilder.provider = jsonValueProvider
@@ -4361,7 +4361,7 @@ public extension Pogoprotos.Networking.Envelopes {
               }
             }
           }
-          class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.Signature.AndroidGpsInfo.Builder {
+          override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.Signature.AndroidGpsInfo.Builder {
             let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.Signature.AndroidGpsInfo.Builder()
             if let jsonValueTimeToFix = jsonMap["timeToFix"] as? String {
               resultDecodedBuilder.timeToFix = UInt64(jsonValueTimeToFix)!
@@ -5402,7 +5402,7 @@ public extension Pogoprotos.Networking.Envelopes {
               }
             }
           }
-          class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.Signature.SensorInfo.Builder {
+          override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.Signature.SensorInfo.Builder {
             let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.Signature.SensorInfo.Builder()
             if let jsonValueTimestampSnapshot = jsonMap["timestampSnapshot"] as? String {
               resultDecodedBuilder.timestampSnapshot = UInt64(jsonValueTimestampSnapshot)!
@@ -6232,7 +6232,7 @@ public extension Pogoprotos.Networking.Envelopes {
               }
             }
           }
-          class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.Signature.DeviceInfo.Builder {
+          override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.Signature.DeviceInfo.Builder {
             let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.Signature.DeviceInfo.Builder()
             if let jsonValueDeviceId = jsonMap["deviceId"] as? String {
               resultDecodedBuilder.deviceId = jsonValueDeviceId
@@ -6850,7 +6850,7 @@ public extension Pogoprotos.Networking.Envelopes {
               }
             }
           }
-          class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.Signature.ActivityStatus.Builder {
+          override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.Signature.ActivityStatus.Builder {
             let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.Signature.ActivityStatus.Builder()
             if let jsonValueStartTimeMs = jsonMap["startTimeMs"] as? String {
               resultDecodedBuilder.startTimeMs = UInt64(jsonValueStartTimeMs)!
@@ -8309,7 +8309,7 @@ public extension Pogoprotos.Networking.Envelopes {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.Signature.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.Signature.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.Signature.Builder()
         if let jsonValueField1 = jsonMap["field1"] as? Array<Dictionary<String,Any>> {
           var jsonArrayField1:Array<Pogoprotos.Networking.Envelopes.UnknownMessage> = []
@@ -8569,7 +8569,7 @@ public extension Pogoprotos.Networking.Envelopes {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.UnknownMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Envelopes.UnknownMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Envelopes.UnknownMessage.Builder()
         return resultDecodedBuilder
       }

--- a/PGoApi/Classes/protos/Pogoprotos.Networking.Platform.Requests.PogoprotosNetworkingPlatformRequests.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Networking.Platform.Requests.PogoprotosNetworkingPlatformRequests.proto.swift
@@ -235,7 +235,7 @@ public extension Pogoprotos.Networking.Platform.Requests {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Requests.BuyItemAndroidRequest.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Requests.BuyItemAndroidRequest.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Platform.Requests.BuyItemAndroidRequest.Builder()
         if let jsonValueBuyItemIntent = jsonMap["buyItemIntent"] as? String {
           resultDecodedBuilder.buyItemIntent = jsonValueBuyItemIntent
@@ -433,7 +433,7 @@ public extension Pogoprotos.Networking.Platform.Requests {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Requests.BuyItemPokeCoinsRequest.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Requests.BuyItemPokeCoinsRequest.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Platform.Requests.BuyItemPokeCoinsRequest.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = jsonValueItemId
@@ -631,7 +631,7 @@ public extension Pogoprotos.Networking.Platform.Requests {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Requests.SendEncryptedSignatureRequest.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Requests.SendEncryptedSignatureRequest.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Platform.Requests.SendEncryptedSignatureRequest.Builder()
         if let jsonValueEncryptedSignature = jsonMap["encryptedSignature"] as? String {
           resultDecodedBuilder.encryptedSignature = Data(base64Encoded:jsonValueEncryptedSignature, options: Data.Base64DecodingOptions(rawValue:0))!

--- a/PGoApi/Classes/protos/Pogoprotos.Networking.Platform.Responses.PogoprotosNetworkingPlatformResponses.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Networking.Platform.Responses.PogoprotosNetworkingPlatformResponses.proto.swift
@@ -361,7 +361,7 @@ public extension Pogoprotos.Networking.Platform.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Responses.BuyItemAndroidResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Responses.BuyItemAndroidResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Platform.Responses.BuyItemAndroidResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Platform.Responses.BuyItemAndroidResponse.Status.fromString(str: jsonValueResult)
@@ -603,7 +603,7 @@ public extension Pogoprotos.Networking.Platform.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Responses.BuyItemPokeCoinsResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Responses.BuyItemPokeCoinsResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Platform.Responses.BuyItemPokeCoinsResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Platform.Responses.BuyItemPokeCoinsResponse.Status.fromString(str: jsonValueResult)
@@ -858,7 +858,7 @@ public extension Pogoprotos.Networking.Platform.Responses {
                   }
                 }
               }
-              class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Responses.GetStoreItemsResponse.StoreItem.TagsEntry.Builder {
+              override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Responses.GetStoreItemsResponse.StoreItem.TagsEntry.Builder {
                 let resultDecodedBuilder = Pogoprotos.Networking.Platform.Responses.GetStoreItemsResponse.StoreItem.TagsEntry.Builder()
                 if let jsonValueKey = jsonMap["key"] as? String {
                   resultDecodedBuilder.key = jsonValueKey
@@ -1481,7 +1481,7 @@ public extension Pogoprotos.Networking.Platform.Responses {
               }
             }
           }
-          class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Responses.GetStoreItemsResponse.StoreItem.Builder {
+          override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Responses.GetStoreItemsResponse.StoreItem.Builder {
             let resultDecodedBuilder = Pogoprotos.Networking.Platform.Responses.GetStoreItemsResponse.StoreItem.Builder()
             if let jsonValueItemId = jsonMap["itemId"] as? String {
               resultDecodedBuilder.itemId = jsonValueItemId
@@ -1888,7 +1888,7 @@ public extension Pogoprotos.Networking.Platform.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Responses.GetStoreItemsResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Responses.GetStoreItemsResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Platform.Responses.GetStoreItemsResponse.Builder()
         if let jsonValueStatus = jsonMap["status"] as? String {
           resultDecodedBuilder.status = try Pogoprotos.Networking.Platform.Responses.GetStoreItemsResponse.Status.fromString(str: jsonValueStatus)
@@ -2108,7 +2108,7 @@ public extension Pogoprotos.Networking.Platform.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Responses.SendEncryptedSignatureResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Platform.Responses.SendEncryptedSignatureResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Platform.Responses.SendEncryptedSignatureResponse.Builder()
         if let jsonValueReceived = jsonMap["received"] as? Bool {
           resultDecodedBuilder.received = jsonValueReceived

--- a/PGoApi/Classes/protos/Pogoprotos.Networking.Requests.Messages.PogoprotosNetworkingRequestsMessages.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Networking.Requests.Messages.PogoprotosNetworkingRequestsMessages.proto.swift
@@ -996,7 +996,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.AddFortModifierMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.AddFortModifierMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.AddFortModifierMessage.Builder()
         if let jsonValueModifierType = jsonMap["modifierType"] as? String {
           resultDecodedBuilder.modifierType = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueModifierType)
@@ -1480,7 +1480,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.AttackGymMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.AttackGymMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.AttackGymMessage.Builder()
         if let jsonValueGymId = jsonMap["gymId"] as? String {
           resultDecodedBuilder.gymId = jsonValueGymId
@@ -1986,7 +1986,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.CatchPokemonMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.CatchPokemonMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.CatchPokemonMessage.Builder()
         if let jsonValueEncounterId = jsonMap["encounterId"] as? String {
           resultDecodedBuilder.encounterId = UInt64(jsonValueEncounterId)!
@@ -2156,7 +2156,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.CheckAwardedBadgesMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.CheckAwardedBadgesMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.CheckAwardedBadgesMessage.Builder()
         return resultDecodedBuilder
       }
@@ -2351,7 +2351,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.CheckChallengeMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.CheckChallengeMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.CheckChallengeMessage.Builder()
         if let jsonValueDebugRequest = jsonMap["debugRequest"] as? Bool {
           resultDecodedBuilder.debugRequest = jsonValueDebugRequest
@@ -2549,7 +2549,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.CheckCodenameAvailableMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.CheckCodenameAvailableMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.CheckCodenameAvailableMessage.Builder()
         if let jsonValueCodename = jsonMap["codename"] as? String {
           resultDecodedBuilder.codename = jsonValueCodename
@@ -2747,7 +2747,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.ClaimCodenameMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.ClaimCodenameMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.ClaimCodenameMessage.Builder()
         if let jsonValueCodename = jsonMap["codename"] as? String {
           resultDecodedBuilder.codename = jsonValueCodename
@@ -2899,7 +2899,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.CollectDailyBonusMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.CollectDailyBonusMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.CollectDailyBonusMessage.Builder()
         return resultDecodedBuilder
       }
@@ -3048,7 +3048,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.CollectDailyDefenderBonusMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.CollectDailyDefenderBonusMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.CollectDailyDefenderBonusMessage.Builder()
         return resultDecodedBuilder
       }
@@ -3384,7 +3384,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.DiskEncounterMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.DiskEncounterMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.DiskEncounterMessage.Builder()
         if let jsonValueEncounterId = jsonMap["encounterId"] as? String {
           resultDecodedBuilder.encounterId = UInt64(jsonValueEncounterId)!
@@ -3545,7 +3545,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.DownloadItemTemplatesMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.DownloadItemTemplatesMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.DownloadItemTemplatesMessage.Builder()
         return resultDecodedBuilder
       }
@@ -3932,7 +3932,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.DownloadRemoteConfigVersionMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.DownloadRemoteConfigVersionMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.DownloadRemoteConfigVersionMessage.Builder()
         if let jsonValuePlatform = jsonMap["platform"] as? String {
           resultDecodedBuilder.platform = try Pogoprotos.Enums.Platform.fromString(str: jsonValuePlatform)
@@ -4142,7 +4142,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.DownloadSettingsMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.DownloadSettingsMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.DownloadSettingsMessage.Builder()
         if let jsonValueHash = jsonMap["hash"] as? String {
           resultDecodedBuilder.hash = jsonValueHash
@@ -4294,7 +4294,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.EchoMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.EchoMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.EchoMessage.Builder()
         return resultDecodedBuilder
       }
@@ -4630,7 +4630,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.EncounterMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.EncounterMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.EncounterMessage.Builder()
         if let jsonValueEncounterId = jsonMap["encounterId"] as? String {
           resultDecodedBuilder.encounterId = UInt64(jsonValueEncounterId)!
@@ -4841,7 +4841,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.EncounterTutorialCompleteMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.EncounterTutorialCompleteMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.EncounterTutorialCompleteMessage.Builder()
         if let jsonValuePokemonId = jsonMap["pokemonId"] as? String {
           resultDecodedBuilder.pokemonId = try Pogoprotos.Enums.PokemonId.fromString(str: jsonValuePokemonId)
@@ -5043,7 +5043,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.EquipBadgeMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.EquipBadgeMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.EquipBadgeMessage.Builder()
         if let jsonValueBadgeType = jsonMap["badgeType"] as? String {
           resultDecodedBuilder.badgeType = try Pogoprotos.Enums.BadgeType.fromString(str: jsonValueBadgeType)
@@ -5241,7 +5241,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.EvolvePokemonMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.EvolvePokemonMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.EvolvePokemonMessage.Builder()
         if let jsonValuePokemonId = jsonMap["pokemonId"] as? String {
           resultDecodedBuilder.pokemonId = UInt64(jsonValuePokemonId)!
@@ -5580,7 +5580,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.FortDeployPokemonMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.FortDeployPokemonMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.FortDeployPokemonMessage.Builder()
         if let jsonValueFortId = jsonMap["fortId"] as? String {
           resultDecodedBuilder.fortId = jsonValueFortId
@@ -5881,7 +5881,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.FortDetailsMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.FortDetailsMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.FortDetailsMessage.Builder()
         if let jsonValueFortId = jsonMap["fortId"] as? String {
           resultDecodedBuilder.fortId = jsonValueFortId
@@ -6226,7 +6226,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.FortRecallPokemonMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.FortRecallPokemonMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.FortRecallPokemonMessage.Builder()
         if let jsonValueFortId = jsonMap["fortId"] as? String {
           resultDecodedBuilder.fortId = jsonValueFortId
@@ -6621,7 +6621,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.FortSearchMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.FortSearchMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.FortSearchMessage.Builder()
         if let jsonValueFortId = jsonMap["fortId"] as? String {
           resultDecodedBuilder.fortId = jsonValueFortId
@@ -7023,7 +7023,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetAssetDigestMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetAssetDigestMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.GetAssetDigestMessage.Builder()
         if let jsonValuePlatform = jsonMap["platform"] as? String {
           resultDecodedBuilder.platform = try Pogoprotos.Enums.Platform.fromString(str: jsonValuePlatform)
@@ -7186,7 +7186,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetBuddyWalkedMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetBuddyWalkedMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.GetBuddyWalkedMessage.Builder()
         return resultDecodedBuilder
       }
@@ -7379,7 +7379,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetDownloadUrlsMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetDownloadUrlsMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.GetDownloadUrlsMessage.Builder()
         if let jsonValueAssetId = jsonMap["assetId"] as? Array<String> {
           resultDecodedBuilder.assetId = jsonValueAssetId
@@ -7812,7 +7812,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetGymDetailsMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetGymDetailsMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.GetGymDetailsMessage.Builder()
         if let jsonValueGymId = jsonMap["gymId"] as? String {
           resultDecodedBuilder.gymId = jsonValueGymId
@@ -7979,7 +7979,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetHatchedEggsMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetHatchedEggsMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.GetHatchedEggsMessage.Builder()
         return resultDecodedBuilder
       }
@@ -8221,7 +8221,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetIncensePokemonMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetIncensePokemonMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.GetIncensePokemonMessage.Builder()
         if let jsonValuePlayerLatitude = jsonMap["playerLatitude"] as? NSNumber {
           resultDecodedBuilder.playerLatitude = jsonValuePlayerLatitude.doubleValue
@@ -8470,7 +8470,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetInventoryMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetInventoryMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.GetInventoryMessage.Builder()
         if let jsonValueLastTimestampMs = jsonMap["lastTimestampMs"] as? String {
           resultDecodedBuilder.lastTimestampMs = Int64(jsonValueLastTimestampMs)!
@@ -8840,7 +8840,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetMapObjectsMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetMapObjectsMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.GetMapObjectsMessage.Builder()
         if let jsonValueCellId = jsonMap["cellId"] as? Array<String> {
           var jsonArrayCellId:Array<UInt64> = []
@@ -9154,7 +9154,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
               }
             }
           }
-          class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetPlayerMessage.PlayerLocale.Builder {
+          override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetPlayerMessage.PlayerLocale.Builder {
             let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.GetPlayerMessage.PlayerLocale.Builder()
             if let jsonValueCountry = jsonMap["country"] as? String {
               resultDecodedBuilder.country = jsonValueCountry
@@ -9399,7 +9399,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetPlayerMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetPlayerMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.GetPlayerMessage.Builder()
         if let jsonValuePlayerLocale = jsonMap["playerLocale"] as? Dictionary<String,Any> {
           resultDecodedBuilder.playerLocale = try Pogoprotos.Networking.Requests.Messages.GetPlayerMessage.PlayerLocale.Builder.decodeToBuilder(jsonMap:jsonValuePlayerLocale).build()
@@ -9598,7 +9598,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetPlayerProfileMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetPlayerProfileMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.GetPlayerProfileMessage.Builder()
         if let jsonValuePlayerName = jsonMap["playerName"] as? String {
           resultDecodedBuilder.playerName = jsonValuePlayerName
@@ -9750,7 +9750,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetSuggestedCodenamesMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.GetSuggestedCodenamesMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.GetSuggestedCodenamesMessage.Builder()
         return resultDecodedBuilder
       }
@@ -9992,7 +9992,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.IncenseEncounterMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.IncenseEncounterMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.IncenseEncounterMessage.Builder()
         if let jsonValueEncounterId = jsonMap["encounterId"] as? String {
           resultDecodedBuilder.encounterId = UInt64(jsonValueEncounterId)!
@@ -10193,7 +10193,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.LevelUpRewardsMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.LevelUpRewardsMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.LevelUpRewardsMessage.Builder()
         if let jsonValueLevel = jsonMap["level"] as? NSNumber {
           resultDecodedBuilder.level = jsonValueLevel.int32Value
@@ -10491,7 +10491,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.MarkTutorialCompleteMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.MarkTutorialCompleteMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.MarkTutorialCompleteMessage.Builder()
         if let jsonValueTutorialsCompleted = jsonMap["tutorialsCompleted"] as? Array<String> {
           var jsonArrayTutorialsCompleted:Array<Pogoprotos.Enums.TutorialState> = []
@@ -10747,7 +10747,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.NicknamePokemonMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.NicknamePokemonMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.NicknamePokemonMessage.Builder()
         if let jsonValuePokemonId = jsonMap["pokemonId"] as? String {
           resultDecodedBuilder.pokemonId = UInt64(jsonValuePokemonId)!
@@ -10995,7 +10995,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.PlayerUpdateMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.PlayerUpdateMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.PlayerUpdateMessage.Builder()
         if let jsonValueLatitude = jsonMap["latitude"] as? NSNumber {
           resultDecodedBuilder.latitude = jsonValueLatitude.doubleValue
@@ -11247,7 +11247,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.RecycleInventoryItemMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.RecycleInventoryItemMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.RecycleInventoryItemMessage.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueItemId)
@@ -11495,7 +11495,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.RegisterBackgroundDeviceMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.RegisterBackgroundDeviceMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.RegisterBackgroundDeviceMessage.Builder()
         if let jsonValueDeviceType = jsonMap["deviceType"] as? String {
           resultDecodedBuilder.deviceType = jsonValueDeviceType
@@ -11696,7 +11696,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.ReleasePokemonMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.ReleasePokemonMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.ReleasePokemonMessage.Builder()
         if let jsonValuePokemonId = jsonMap["pokemonId"] as? String {
           resultDecodedBuilder.pokemonId = UInt64(jsonValuePokemonId)!
@@ -11934,7 +11934,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.SetAvatarMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.SetAvatarMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.SetAvatarMessage.Builder()
         if let jsonValuePlayerAvatar = jsonMap["playerAvatar"] as? Dictionary<String,Any> {
           resultDecodedBuilder.playerAvatar = try Pogoprotos.Data.Player.PlayerAvatar.Builder.decodeToBuilder(jsonMap:jsonValuePlayerAvatar).build()
@@ -12133,7 +12133,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.SetBuddyPokemonMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.SetBuddyPokemonMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.SetBuddyPokemonMessage.Builder()
         if let jsonValuePokemonId = jsonMap["pokemonId"] as? String {
           resultDecodedBuilder.pokemonId = UInt64(jsonValuePokemonId)!
@@ -12371,7 +12371,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.SetContactSettingsMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.SetContactSettingsMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.SetContactSettingsMessage.Builder()
         if let jsonValueContactSettings = jsonMap["contactSettings"] as? Dictionary<String,Any> {
           resultDecodedBuilder.contactSettings = try Pogoprotos.Data.Player.ContactSettings.Builder.decodeToBuilder(jsonMap:jsonValueContactSettings).build()
@@ -12618,7 +12618,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.SetFavoritePokemonMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.SetFavoritePokemonMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.SetFavoritePokemonMessage.Builder()
         if let jsonValuePokemonId = jsonMap["pokemonId"] as? String {
           resultDecodedBuilder.pokemonId = Int64(jsonValuePokemonId)!
@@ -12823,7 +12823,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.SetPlayerTeamMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.SetPlayerTeamMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.SetPlayerTeamMessage.Builder()
         if let jsonValueTeam = jsonMap["team"] as? String {
           resultDecodedBuilder.team = try Pogoprotos.Enums.TeamColor.fromString(str: jsonValueTeam)
@@ -12975,7 +12975,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.SfidaActionLogMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.SfidaActionLogMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.SfidaActionLogMessage.Builder()
         return resultDecodedBuilder
       }
@@ -13371,7 +13371,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.StartGymBattleMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.StartGymBattleMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.StartGymBattleMessage.Builder()
         if let jsonValueGymId = jsonMap["gymId"] as? String {
           resultDecodedBuilder.gymId = jsonValueGymId
@@ -13585,7 +13585,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UpgradePokemonMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UpgradePokemonMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.UpgradePokemonMessage.Builder()
         if let jsonValuePokemonId = jsonMap["pokemonId"] as? String {
           resultDecodedBuilder.pokemonId = UInt64(jsonValuePokemonId)!
@@ -13787,7 +13787,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseIncenseMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseIncenseMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.UseIncenseMessage.Builder()
         if let jsonValueIncenseType = jsonMap["incenseType"] as? String {
           resultDecodedBuilder.incenseType = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueIncenseType)
@@ -14083,7 +14083,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseItemCaptureMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseItemCaptureMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.UseItemCaptureMessage.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueItemId)
@@ -14334,7 +14334,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseItemEggIncubatorMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseItemEggIncubatorMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.UseItemEggIncubatorMessage.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = jsonValueItemId
@@ -14680,7 +14680,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseItemGymMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseItemGymMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.UseItemGymMessage.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueItemId)
@@ -14938,7 +14938,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseItemPotionMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseItemPotionMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.UseItemPotionMessage.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueItemId)
@@ -15190,7 +15190,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseItemReviveMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseItemReviveMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.UseItemReviveMessage.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueItemId)
@@ -15395,7 +15395,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseItemXpBoostMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.UseItemXpBoostMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.UseItemXpBoostMessage.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueItemId)
@@ -15593,7 +15593,7 @@ public extension Pogoprotos.Networking.Requests.Messages {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.VerifyChallengeMessage.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Messages.VerifyChallengeMessage.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Messages.VerifyChallengeMessage.Builder()
         if let jsonValueToken = jsonMap["token"] as? String {
           resultDecodedBuilder.token = jsonValueToken

--- a/PGoApi/Classes/protos/Pogoprotos.Networking.Requests.PogoprotosNetworkingRequests.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Networking.Requests.PogoprotosNetworkingRequests.proto.swift
@@ -741,7 +741,7 @@ public extension Pogoprotos.Networking.Requests {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Request.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Requests.Request.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Requests.Request.Builder()
         if let jsonValueRequestType = jsonMap["requestType"] as? String {
           resultDecodedBuilder.requestType = try Pogoprotos.Networking.Requests.RequestType.fromString(str: jsonValueRequestType)

--- a/PGoApi/Classes/protos/Pogoprotos.Networking.Responses.PogoprotosNetworkingResponses.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Networking.Responses.PogoprotosNetworkingResponses.proto.swift
@@ -1070,7 +1070,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.AddFortModifierResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.AddFortModifierResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.AddFortModifierResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.AddFortModifierResponse.Result.fromString(str: jsonValueResult)
@@ -1624,7 +1624,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.AttackGymResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.AttackGymResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.AttackGymResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.AttackGymResponse.Result.fromString(str: jsonValueResult)
@@ -2153,7 +2153,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.CatchPokemonResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.CatchPokemonResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.CatchPokemonResponse.Builder()
         if let jsonValueStatus = jsonMap["status"] as? String {
           resultDecodedBuilder.status = try Pogoprotos.Networking.Responses.CatchPokemonResponse.CatchStatus.fromString(str: jsonValueStatus)
@@ -2478,7 +2478,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.CheckAwardedBadgesResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.CheckAwardedBadgesResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.CheckAwardedBadgesResponse.Builder()
         if let jsonValueSuccess = jsonMap["success"] as? Bool {
           resultDecodedBuilder.success = jsonValueSuccess
@@ -2738,7 +2738,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.CheckChallengeResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.CheckChallengeResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.CheckChallengeResponse.Builder()
         if let jsonValueShowChallenge = jsonMap["showChallenge"] as? Bool {
           resultDecodedBuilder.showChallenge = jsonValueShowChallenge
@@ -3132,7 +3132,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.CheckCodenameAvailableResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.CheckCodenameAvailableResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.CheckCodenameAvailableResponse.Builder()
         if let jsonValueCodename = jsonMap["codename"] as? String {
           resultDecodedBuilder.codename = jsonValueCodename
@@ -3619,7 +3619,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.ClaimCodenameResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.ClaimCodenameResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.ClaimCodenameResponse.Builder()
         if let jsonValueCodename = jsonMap["codename"] as? String {
           resultDecodedBuilder.codename = jsonValueCodename
@@ -3874,7 +3874,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.CollectDailyBonusResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.CollectDailyBonusResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.CollectDailyBonusResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.CollectDailyBonusResponse.Result.fromString(str: jsonValueResult)
@@ -4273,7 +4273,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.CollectDailyDefenderBonusResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.CollectDailyDefenderBonusResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.CollectDailyDefenderBonusResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.CollectDailyDefenderBonusResponse.Result.fromString(str: jsonValueResult)
@@ -4710,7 +4710,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.DiskEncounterResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.DiskEncounterResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.DiskEncounterResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.DiskEncounterResponse.Result.fromString(str: jsonValueResult)
@@ -6313,7 +6313,7 @@ public extension Pogoprotos.Networking.Responses {
               }
             }
           }
-          class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.DownloadItemTemplatesResponse.ItemTemplate.Builder {
+          override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.DownloadItemTemplatesResponse.ItemTemplate.Builder {
             let resultDecodedBuilder = Pogoprotos.Networking.Responses.DownloadItemTemplatesResponse.ItemTemplate.Builder()
             if let jsonValueTemplateId = jsonMap["templateId"] as? String {
               resultDecodedBuilder.templateId = jsonValueTemplateId
@@ -6672,7 +6672,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.DownloadItemTemplatesResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.DownloadItemTemplatesResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.DownloadItemTemplatesResponse.Builder()
         if let jsonValueSuccess = jsonMap["success"] as? Bool {
           resultDecodedBuilder.success = jsonValueSuccess
@@ -7013,7 +7013,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.DownloadRemoteConfigVersionResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.DownloadRemoteConfigVersionResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.DownloadRemoteConfigVersionResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.DownloadRemoteConfigVersionResponse.Result.fromString(str: jsonValueResult)
@@ -7351,7 +7351,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.DownloadSettingsResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.DownloadSettingsResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.DownloadSettingsResponse.Builder()
         if let jsonValueError = jsonMap["error"] as? String {
           resultDecodedBuilder.error = jsonValueError
@@ -7556,7 +7556,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.EchoResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.EchoResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.EchoResponse.Builder()
         if let jsonValueContext = jsonMap["context"] as? String {
           resultDecodedBuilder.context = jsonValueContext
@@ -8071,7 +8071,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.EncounterResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.EncounterResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.EncounterResponse.Builder()
         if let jsonValueWildPokemon = jsonMap["wildPokemon"] as? Dictionary<String,Any> {
           resultDecodedBuilder.wildPokemon = try Pogoprotos.Map.Pokemon.WildPokemon.Builder.decodeToBuilder(jsonMap:jsonValueWildPokemon).build()
@@ -8494,7 +8494,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.EncounterTutorialCompleteResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.EncounterTutorialCompleteResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.EncounterTutorialCompleteResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.EncounterTutorialCompleteResponse.Result.fromString(str: jsonValueResult)
@@ -8831,7 +8831,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.EquipBadgeResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.EquipBadgeResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.EquipBadgeResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.EquipBadgeResponse.Result.fromString(str: jsonValueResult)
@@ -9266,7 +9266,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.EvolvePokemonResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.EvolvePokemonResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.EvolvePokemonResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.EvolvePokemonResponse.Result.fromString(str: jsonValueResult)
@@ -9807,7 +9807,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.FortDeployPokemonResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.FortDeployPokemonResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.FortDeployPokemonResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.FortDeployPokemonResponse.Result.fromString(str: jsonValueResult)
@@ -10629,7 +10629,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.FortDetailsResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.FortDetailsResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.FortDetailsResponse.Builder()
         if let jsonValueFortId = jsonMap["fortId"] as? String {
           resultDecodedBuilder.fortId = jsonValueFortId
@@ -11005,7 +11005,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.FortRecallPokemonResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.FortRecallPokemonResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.FortRecallPokemonResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.FortRecallPokemonResponse.Result.fromString(str: jsonValueResult)
@@ -11583,7 +11583,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.FortSearchResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.FortSearchResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.FortSearchResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.FortSearchResponse.Result.fromString(str: jsonValueResult)
@@ -11855,7 +11855,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetAssetDigestResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetAssetDigestResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.GetAssetDigestResponse.Builder()
         if let jsonValueDigest = jsonMap["digest"] as? Array<Dictionary<String,Any>> {
           var jsonArrayDigest:Array<Pogoprotos.Data.AssetDigestEntry> = []
@@ -12160,7 +12160,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetBuddyWalkedResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetBuddyWalkedResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.GetBuddyWalkedResponse.Builder()
         if let jsonValueSuccess = jsonMap["success"] as? Bool {
           resultDecodedBuilder.success = jsonValueSuccess
@@ -12366,7 +12366,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetDownloadUrlsResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetDownloadUrlsResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.GetDownloadUrlsResponse.Builder()
         if let jsonValueDownloadUrls = jsonMap["downloadUrls"] as? Array<Dictionary<String,Any>> {
           var jsonArrayDownloadUrls:Array<Pogoprotos.Data.DownloadUrlEntry> = []
@@ -12836,7 +12836,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetGymDetailsResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetGymDetailsResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.GetGymDetailsResponse.Builder()
         if let jsonValueGymState = jsonMap["gymState"] as? Dictionary<String,Any> {
           resultDecodedBuilder.gymState = try Pogoprotos.Data.Gym.GymState.Builder.decodeToBuilder(jsonMap:jsonValueGymState).build()
@@ -13348,7 +13348,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetHatchedEggsResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetHatchedEggsResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.GetHatchedEggsResponse.Builder()
         if let jsonValueSuccess = jsonMap["success"] as? Bool {
           resultDecodedBuilder.success = jsonValueSuccess
@@ -13907,7 +13907,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetIncensePokemonResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetIncensePokemonResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.GetIncensePokemonResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.GetIncensePokemonResponse.Result.fromString(str: jsonValueResult)
@@ -14210,7 +14210,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetInventoryResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetInventoryResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.GetInventoryResponse.Builder()
         if let jsonValueSuccess = jsonMap["success"] as? Bool {
           resultDecodedBuilder.success = jsonValueSuccess
@@ -14465,7 +14465,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetMapObjectsResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetMapObjectsResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.GetMapObjectsResponse.Builder()
         if let jsonValueMapCells = jsonMap["mapCells"] as? Array<Dictionary<String,Any>> {
           var jsonArrayMapCells:Array<Pogoprotos.Map.MapCell> = []
@@ -14804,7 +14804,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetPlayerProfileResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetPlayerProfileResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.GetPlayerProfileResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.GetPlayerProfileResponse.Result.fromString(str: jsonValueResult)
@@ -15195,7 +15195,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetPlayerResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetPlayerResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.GetPlayerResponse.Builder()
         if let jsonValueSuccess = jsonMap["success"] as? Bool {
           resultDecodedBuilder.success = jsonValueSuccess
@@ -15448,7 +15448,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetSuggestedCodenamesResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.GetSuggestedCodenamesResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.GetSuggestedCodenamesResponse.Builder()
         if let jsonValueCodenames = jsonMap["codenames"] as? Array<String> {
           resultDecodedBuilder.codenames = jsonValueCodenames
@@ -15867,7 +15867,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.IncenseEncounterResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.IncenseEncounterResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.IncenseEncounterResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.IncenseEncounterResponse.Result.fromString(str: jsonValueResult)
@@ -16215,7 +16215,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.LevelUpRewardsResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.LevelUpRewardsResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.LevelUpRewardsResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.LevelUpRewardsResponse.Result.fromString(str: jsonValueResult)
@@ -16517,7 +16517,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.MarkTutorialCompleteResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.MarkTutorialCompleteResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.MarkTutorialCompleteResponse.Builder()
         if let jsonValueSuccess = jsonMap["success"] as? Bool {
           resultDecodedBuilder.success = jsonValueSuccess
@@ -16767,7 +16767,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.NicknamePokemonResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.NicknamePokemonResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.NicknamePokemonResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.NicknamePokemonResponse.Result.fromString(str: jsonValueResult)
@@ -17063,7 +17063,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.PlayerUpdateResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.PlayerUpdateResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.PlayerUpdateResponse.Builder()
         if let jsonValueWildPokemons = jsonMap["wildPokemons"] as? Array<Dictionary<String,Any>> {
           var jsonArrayWildPokemons:Array<Pogoprotos.Map.Pokemon.WildPokemon> = []
@@ -17370,7 +17370,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.RecycleInventoryItemResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.RecycleInventoryItemResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.RecycleInventoryItemResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.RecycleInventoryItemResponse.Result.fromString(str: jsonValueResult)
@@ -17698,7 +17698,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.RegisterBackgroundDeviceResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.RegisterBackgroundDeviceResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.RegisterBackgroundDeviceResponse.Builder()
         if let jsonValueStatus = jsonMap["status"] as? String {
           resultDecodedBuilder.status = try Pogoprotos.Networking.Responses.RegisterBackgroundDeviceResponse.Status.fromString(str: jsonValueStatus)
@@ -17999,7 +17999,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.ReleasePokemonResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.ReleasePokemonResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.ReleasePokemonResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.ReleasePokemonResponse.Result.fromString(str: jsonValueResult)
@@ -18331,7 +18331,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.SetAvatarResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.SetAvatarResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.SetAvatarResponse.Builder()
         if let jsonValueStatus = jsonMap["status"] as? String {
           resultDecodedBuilder.status = try Pogoprotos.Networking.Responses.SetAvatarResponse.Status.fromString(str: jsonValueStatus)
@@ -18668,7 +18668,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.SetBuddyPokemonResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.SetBuddyPokemonResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.SetBuddyPokemonResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.SetBuddyPokemonResponse.Result.fromString(str: jsonValueResult)
@@ -18997,7 +18997,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.SetContactSettingsResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.SetContactSettingsResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.SetContactSettingsResponse.Builder()
         if let jsonValueStatus = jsonMap["status"] as? String {
           resultDecodedBuilder.status = try Pogoprotos.Networking.Responses.SetContactSettingsResponse.Status.fromString(str: jsonValueStatus)
@@ -19243,7 +19243,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.SetFavoritePokemonResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.SetFavoritePokemonResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.SetFavoritePokemonResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.SetFavoritePokemonResponse.Result.fromString(str: jsonValueResult)
@@ -19572,7 +19572,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.SetPlayerTeamResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.SetPlayerTeamResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.SetPlayerTeamResponse.Builder()
         if let jsonValueStatus = jsonMap["status"] as? String {
           resultDecodedBuilder.status = try Pogoprotos.Networking.Responses.SetPlayerTeamResponse.Status.fromString(str: jsonValueStatus)
@@ -19859,7 +19859,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.SfidaActionLogResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.SfidaActionLogResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.SfidaActionLogResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.SfidaActionLogResponse.Result.fromString(str: jsonValueResult)
@@ -20552,7 +20552,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.StartGymBattleResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.StartGymBattleResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.StartGymBattleResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.StartGymBattleResponse.Result.fromString(str: jsonValueResult)
@@ -20910,7 +20910,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UpgradePokemonResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UpgradePokemonResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.UpgradePokemonResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.UpgradePokemonResponse.Result.fromString(str: jsonValueResult)
@@ -21247,7 +21247,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseIncenseResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseIncenseResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.UseIncenseResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.UseIncenseResponse.Result.fromString(str: jsonValueResult)
@@ -21731,7 +21731,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseItemCaptureResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseItemCaptureResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.UseItemCaptureResponse.Builder()
         if let jsonValueSuccess = jsonMap["success"] as? Bool {
           resultDecodedBuilder.success = jsonValueSuccess
@@ -22094,7 +22094,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseItemEggIncubatorResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseItemEggIncubatorResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.UseItemEggIncubatorResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.UseItemEggIncubatorResponse.Result.fromString(str: jsonValueResult)
@@ -22388,7 +22388,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseItemGymResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseItemGymResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.UseItemGymResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.UseItemGymResponse.Result.fromString(str: jsonValueResult)
@@ -22684,7 +22684,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseItemPotionResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseItemPotionResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.UseItemPotionResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.UseItemPotionResponse.Result.fromString(str: jsonValueResult)
@@ -22980,7 +22980,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseItemReviveResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseItemReviveResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.UseItemReviveResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.UseItemReviveResponse.Result.fromString(str: jsonValueResult)
@@ -23320,7 +23320,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseItemXpBoostResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.UseItemXpBoostResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.UseItemXpBoostResponse.Builder()
         if let jsonValueResult = jsonMap["result"] as? String {
           resultDecodedBuilder.result = try Pogoprotos.Networking.Responses.UseItemXpBoostResponse.Result.fromString(str: jsonValueResult)
@@ -23522,7 +23522,7 @@ public extension Pogoprotos.Networking.Responses {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.VerifyChallengeResponse.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Networking.Responses.VerifyChallengeResponse.Builder {
         let resultDecodedBuilder = Pogoprotos.Networking.Responses.VerifyChallengeResponse.Builder()
         if let jsonValueSuccess = jsonMap["success"] as? Bool {
           resultDecodedBuilder.success = jsonValueSuccess

--- a/PGoApi/Classes/protos/Pogoprotos.Settings.Master.Item.PogoprotosSettingsMasterItem.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Settings.Master.Item.PogoprotosSettingsMasterItem.proto.swift
@@ -323,7 +323,7 @@ public extension Pogoprotos.Settings.Master.Item {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.BattleAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.BattleAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Item.BattleAttributes.Builder()
         if let jsonValueStaPercent = jsonMap["staPercent"] as? NSNumber {
           resultDecodedBuilder.staPercent = jsonValueStaPercent.floatValue
@@ -619,7 +619,7 @@ public extension Pogoprotos.Settings.Master.Item {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.EggIncubatorAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.EggIncubatorAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Item.EggIncubatorAttributes.Builder()
         if let jsonValueIncubatorType = jsonMap["incubatorType"] as? String {
           resultDecodedBuilder.incubatorType = try Pogoprotos.Inventory.EggIncubatorType.fromString(str: jsonValueIncubatorType)
@@ -870,7 +870,7 @@ public extension Pogoprotos.Settings.Master.Item {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.ExperienceBoostAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.ExperienceBoostAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Item.ExperienceBoostAttributes.Builder()
         if let jsonValueXpMultiplier = jsonMap["xpMultiplier"] as? NSNumber {
           resultDecodedBuilder.xpMultiplier = jsonValueXpMultiplier.floatValue
@@ -1183,7 +1183,7 @@ public extension Pogoprotos.Settings.Master.Item {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.FoodAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.FoodAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Item.FoodAttributes.Builder()
         if let jsonValueItemEffect = jsonMap["itemEffect"] as? Array<String> {
           var jsonArrayItemEffect:Array<Pogoprotos.Enums.ItemEffect> = []
@@ -1443,7 +1443,7 @@ public extension Pogoprotos.Settings.Master.Item {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.FortModifierAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.FortModifierAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Item.FortModifierAttributes.Builder()
         if let jsonValueModifierLifetimeSeconds = jsonMap["modifierLifetimeSeconds"] as? NSNumber {
           resultDecodedBuilder.modifierLifetimeSeconds = jsonValueModifierLifetimeSeconds.int32Value
@@ -1932,7 +1932,7 @@ public extension Pogoprotos.Settings.Master.Item {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.IncenseAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.IncenseAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Item.IncenseAttributes.Builder()
         if let jsonValueIncenseLifetimeSeconds = jsonMap["incenseLifetimeSeconds"] as? NSNumber {
           resultDecodedBuilder.incenseLifetimeSeconds = jsonValueIncenseLifetimeSeconds.int32Value
@@ -2204,7 +2204,7 @@ public extension Pogoprotos.Settings.Master.Item {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.InventoryUpgradeAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.InventoryUpgradeAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Item.InventoryUpgradeAttributes.Builder()
         if let jsonValueAdditionalStorage = jsonMap["additionalStorage"] as? NSNumber {
           resultDecodedBuilder.additionalStorage = jsonValueAdditionalStorage.int32Value
@@ -2550,7 +2550,7 @@ public extension Pogoprotos.Settings.Master.Item {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.PokeballAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.PokeballAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Item.PokeballAttributes.Builder()
         if let jsonValueItemEffect = jsonMap["itemEffect"] as? String {
           resultDecodedBuilder.itemEffect = try Pogoprotos.Enums.ItemEffect.fromString(str: jsonValueItemEffect)
@@ -2804,7 +2804,7 @@ public extension Pogoprotos.Settings.Master.Item {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.PotionAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.PotionAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Item.PotionAttributes.Builder()
         if let jsonValueStaPercent = jsonMap["staPercent"] as? NSNumber {
           resultDecodedBuilder.staPercent = jsonValueStaPercent.floatValue
@@ -3005,7 +3005,7 @@ public extension Pogoprotos.Settings.Master.Item {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.ReviveAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Item.ReviveAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Item.ReviveAttributes.Builder()
         if let jsonValueStaPercent = jsonMap["staPercent"] as? NSNumber {
           resultDecodedBuilder.staPercent = jsonValueStaPercent.floatValue

--- a/PGoApi/Classes/protos/Pogoprotos.Settings.Master.PogoprotosSettingsMaster.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Settings.Master.PogoprotosSettingsMaster.proto.swift
@@ -642,7 +642,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.BadgeSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.BadgeSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.BadgeSettings.Builder()
         if let jsonValueBadgeType = jsonMap["badgeType"] as? String {
           resultDecodedBuilder.badgeType = try Pogoprotos.Enums.BadgeType.fromString(str: jsonValueBadgeType)
@@ -1732,7 +1732,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.CameraSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.CameraSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.CameraSettings.Builder()
         if let jsonValueNextCamera = jsonMap["nextCamera"] as? String {
           resultDecodedBuilder.nextCamera = jsonValueNextCamera
@@ -2225,7 +2225,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.EncounterSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.EncounterSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.EncounterSettings.Builder()
         if let jsonValueSpinBonusThreshold = jsonMap["spinBonusThreshold"] as? NSNumber {
           resultDecodedBuilder.spinBonusThreshold = jsonValueSpinBonusThreshold.floatValue
@@ -2553,7 +2553,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.EquippedBadgeSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.EquippedBadgeSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.EquippedBadgeSettings.Builder()
         if let jsonValueEquipBadgeCooldownMs = jsonMap["equipBadgeCooldownMs"] as? String {
           resultDecodedBuilder.equipBadgeCooldownMs = Int64(jsonValueEquipBadgeCooldownMs)!
@@ -3423,7 +3423,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.GymBattleSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.GymBattleSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.GymBattleSettings.Builder()
         if let jsonValueEnergyPerSec = jsonMap["energyPerSec"] as? NSNumber {
           resultDecodedBuilder.energyPerSec = jsonValueEnergyPerSec.floatValue
@@ -3860,7 +3860,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.GymLevelSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.GymLevelSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.GymLevelSettings.Builder()
         if let jsonValueRequiredExperience = jsonMap["requiredExperience"] as? Array<NSNumber> {
           var jsonArrayRequiredExperience:Array<Int32> = []
@@ -4295,7 +4295,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.IapItemDisplay.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.IapItemDisplay.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.IapItemDisplay.Builder()
         if let jsonValueSku = jsonMap["sku"] as? String {
           resultDecodedBuilder.sku = jsonValueSku
@@ -4808,7 +4808,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.IapSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.IapSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.IapSettings.Builder()
         if let jsonValueDailyBonusCoins = jsonMap["dailyBonusCoins"] as? NSNumber {
           resultDecodedBuilder.dailyBonusCoins = jsonValueDailyBonusCoins.int32Value
@@ -6098,7 +6098,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.ItemSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.ItemSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.ItemSettings.Builder()
         if let jsonValueItemId = jsonMap["itemId"] as? String {
           resultDecodedBuilder.itemId = try Pogoprotos.Inventory.Item.ItemId.fromString(str: jsonValueItemId)
@@ -6346,7 +6346,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.MoveSequenceSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.MoveSequenceSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.MoveSequenceSettings.Builder()
         if let jsonValueSequence = jsonMap["sequence"] as? Array<String> {
           resultDecodedBuilder.sequence = jsonValueSequence
@@ -7210,7 +7210,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.MoveSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.MoveSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.MoveSettings.Builder()
         if let jsonValueMovementId = jsonMap["movementId"] as? String {
           resultDecodedBuilder.movementId = try Pogoprotos.Enums.PokemonMove.fromString(str: jsonValueMovementId)
@@ -7678,7 +7678,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.PlayerLevelSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.PlayerLevelSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.PlayerLevelSettings.Builder()
         if let jsonValueRankNum = jsonMap["rankNum"] as? Array<NSNumber> {
           var jsonArrayRankNum:Array<Int32> = []
@@ -9199,7 +9199,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.PokemonSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.PokemonSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.PokemonSettings.Builder()
         if let jsonValuePokemonId = jsonMap["pokemonId"] as? String {
           resultDecodedBuilder.pokemonId = try Pogoprotos.Enums.PokemonId.fromString(str: jsonValuePokemonId)
@@ -9657,7 +9657,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.PokemonUpgradeSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.PokemonUpgradeSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.PokemonUpgradeSettings.Builder()
         if let jsonValueUpgradesPerLevel = jsonMap["upgradesPerLevel"] as? NSNumber {
           resultDecodedBuilder.upgradesPerLevel = jsonValueUpgradesPerLevel.int32Value
@@ -9963,7 +9963,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.QuestSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.QuestSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.QuestSettings.Builder()
         if let jsonValueQuestType = jsonMap["questType"] as? String {
           resultDecodedBuilder.questType = try Pogoprotos.Enums.QuestType.fromString(str: jsonValueQuestType)
@@ -10228,7 +10228,7 @@ public extension Pogoprotos.Settings.Master {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.TypeEffectiveSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.TypeEffectiveSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.TypeEffectiveSettings.Builder()
         if let jsonValueAttackScalar = jsonMap["attackScalar"] as? Array<NSNumber> {
           var jsonArrayAttackScalar:Array<Float> = []

--- a/PGoApi/Classes/protos/Pogoprotos.Settings.Master.Pokemon.PogoprotosSettingsMasterPokemon.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Settings.Master.Pokemon.PogoprotosSettingsMasterPokemon.proto.swift
@@ -438,7 +438,7 @@ public extension Pogoprotos.Settings.Master.Pokemon {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Pokemon.CameraAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Pokemon.CameraAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Pokemon.CameraAttributes.Builder()
         if let jsonValueDiskRadiusM = jsonMap["diskRadiusM"] as? NSNumber {
           resultDecodedBuilder.diskRadiusM = jsonValueDiskRadiusM.floatValue
@@ -1028,7 +1028,7 @@ public extension Pogoprotos.Settings.Master.Pokemon {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Pokemon.EncounterAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Pokemon.EncounterAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Pokemon.EncounterAttributes.Builder()
         if let jsonValueBaseCaptureRate = jsonMap["baseCaptureRate"] as? NSNumber {
           resultDecodedBuilder.baseCaptureRate = jsonValueBaseCaptureRate.floatValue
@@ -1391,7 +1391,7 @@ public extension Pogoprotos.Settings.Master.Pokemon {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Pokemon.StatsAttributes.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Pokemon.StatsAttributes.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Pokemon.StatsAttributes.Builder()
         if let jsonValueBaseStamina = jsonMap["baseStamina"] as? NSNumber {
           resultDecodedBuilder.baseStamina = jsonValueBaseStamina.int32Value

--- a/PGoApi/Classes/protos/Pogoprotos.Settings.Master.Quest.PogoprotosSettingsMasterQuest.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Settings.Master.Quest.PogoprotosSettingsMasterQuest.proto.swift
@@ -358,7 +358,7 @@ public extension Pogoprotos.Settings.Master.Quest {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Quest.DailyQuestSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.Master.Quest.DailyQuestSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.Master.Quest.DailyQuestSettings.Builder()
         if let jsonValueBucketsPerDay = jsonMap["bucketsPerDay"] as? NSNumber {
           resultDecodedBuilder.bucketsPerDay = jsonValueBucketsPerDay.int32Value

--- a/PGoApi/Classes/protos/Pogoprotos.Settings.PogoprotosSettings.proto.swift
+++ b/PGoApi/Classes/protos/Pogoprotos.Settings.PogoprotosSettings.proto.swift
@@ -334,7 +334,7 @@ public extension Pogoprotos.Settings {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.DownloadSettingsAction.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.DownloadSettingsAction.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.DownloadSettingsAction.Builder()
         if let jsonValueHash = jsonMap["hash"] as? String {
           resultDecodedBuilder.hash = jsonValueHash
@@ -530,7 +530,7 @@ public extension Pogoprotos.Settings {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.EventSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.EventSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.EventSettings.Builder()
         if let jsonValueCondolenceRibbonCountry = jsonMap["condolenceRibbonCountry"] as? Array<String> {
           resultDecodedBuilder.condolenceRibbonCountry = jsonValueCondolenceRibbonCountry
@@ -858,7 +858,7 @@ public extension Pogoprotos.Settings {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.FestivalSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.FestivalSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.FestivalSettings.Builder()
         if let jsonValueFestivalType = jsonMap["festivalType"] as? String {
           resultDecodedBuilder.festivalType = try Pogoprotos.Settings.FestivalSettings.FestivalType.fromString(str: jsonValueFestivalType)
@@ -1297,7 +1297,7 @@ public extension Pogoprotos.Settings {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.FortSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.FortSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.FortSettings.Builder()
         if let jsonValueInteractionRangeMeters = jsonMap["interactionRangeMeters"] as? NSNumber {
           resultDecodedBuilder.interactionRangeMeters = jsonValueInteractionRangeMeters.doubleValue
@@ -2253,7 +2253,7 @@ public extension Pogoprotos.Settings {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.GlobalSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.GlobalSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.GlobalSettings.Builder()
         if let jsonValueFortSettings = jsonMap["fortSettings"] as? Dictionary<String,Any> {
           resultDecodedBuilder.fortSettings = try Pogoprotos.Settings.FortSettings.Builder.decodeToBuilder(jsonMap:jsonValueFortSettings).build()
@@ -2627,7 +2627,7 @@ public extension Pogoprotos.Settings {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.GpsSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.GpsSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.GpsSettings.Builder()
         if let jsonValueDrivingWarningSpeedMetersPerSecond = jsonMap["drivingWarningSpeedMetersPerSecond"] as? NSNumber {
           resultDecodedBuilder.drivingWarningSpeedMetersPerSecond = jsonValueDrivingWarningSpeedMetersPerSecond.floatValue
@@ -3022,7 +3022,7 @@ public extension Pogoprotos.Settings {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.InventorySettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.InventorySettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.InventorySettings.Builder()
         if let jsonValueMaxPokemon = jsonMap["maxPokemon"] as? NSNumber {
           resultDecodedBuilder.maxPokemon = jsonValueMaxPokemon.int32Value
@@ -3279,7 +3279,7 @@ public extension Pogoprotos.Settings {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.LevelSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.LevelSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.LevelSettings.Builder()
         if let jsonValueTrainerCpModifier = jsonMap["trainerCpModifier"] as? NSNumber {
           resultDecodedBuilder.trainerCpModifier = jsonValueTrainerCpModifier.doubleValue
@@ -3762,7 +3762,7 @@ public extension Pogoprotos.Settings {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.MapSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.MapSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.MapSettings.Builder()
         if let jsonValuePokemonVisibleRange = jsonMap["pokemonVisibleRange"] as? NSNumber {
           resultDecodedBuilder.pokemonVisibleRange = jsonValuePokemonVisibleRange.doubleValue
@@ -3978,7 +3978,7 @@ public extension Pogoprotos.Settings {
           }
         }
       }
-      class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.SfidaSettings.Builder {
+      override class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Settings.SfidaSettings.Builder {
         let resultDecodedBuilder = Pogoprotos.Settings.SfidaSettings.Builder()
         if let jsonValueLowBatteryThreshold = jsonMap["lowBatteryThreshold"] as? NSNumber {
           resultDecodedBuilder.lowBatteryThreshold = jsonValueLowBatteryThreshold.floatValue


### PR DESCRIPTION
All of `class public func decodeToBuilder(jsonMap:Dictionary<String,Any>) throws -> Pogoprotos.Data.Badge.BadgeCaptureReward.Builder` must have the prefix `override`